### PR TITLE
feat(workflows): add review-and-fix workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ yalc.lock
 .yalc
 *.code-workspace
 .npmrc
+
+# windsurf
+/.windsurf/outputs/

--- a/.windsurf/rules/commit-message.md
+++ b/.windsurf/rules/commit-message.md
@@ -1,0 +1,23 @@
+---
+trigger: always_on
+---
+
+# Commit Message Format
+
+When generating commit messages, follow the Conventional Commits specification:
+use the @web to read conventional commits guidelines (https://www.conventionalcommits.org/en/v1.0.0/#summary)
+
+- Format: `type(scope): single line description`
+- Never add ``` block for commit message
+- Types: feat, fix, refactor, docs, style, test, chore, perf, ci, build
+- Keep the main message on a single line, clear and concise
+- Add extra details as a markdown bullet list below if needed
+- Each bullet point should include the reason why that change was made
+- Where applicable, provide insight into the impact of not including the change
+
+Example:
+
+feat(auth): add OAuth2 login support
+
+- Added Google OAuth provider — enables single-click login for Google Workspace users
+- Updated user session handling — previous implementation lost sessions on token refresh

--- a/.windsurf/rules/commit-message.md
+++ b/.windsurf/rules/commit-message.md
@@ -5,7 +5,7 @@ trigger: always_on
 # Commit Message Format
 
 When generating commit messages, follow the Conventional Commits specification:
-use the @web to read conventional commits guidelines (https://www.conventionalcommits.org/en/v1.0.0/#summary)
+For more information, see the Conventional Commits specification: https://www.conventionalcommits.org/en/v1.0.0/#summary
 
 - Format: `type(scope): single line description`
 - Never add ``` block for commit message

--- a/.windsurf/rules/prettier.md
+++ b/.windsurf/rules/prettier.md
@@ -1,0 +1,16 @@
+---
+trigger: glob
+globs: **/*.js, **/*.jsx, **/*.ts, **/*.tsx, **/*.css, **/*.scss, **/*.json
+---
+
+# JavaScript & CSS Code Style
+
+## Prettier Formatting
+
+Always format code using Prettier before completing changes.
+
+<instructions>
+1. After making changes, run `npx prettier --write` on modified files
+2. If the repo has a Prettier config file, follow it (otherwise use Prettier defaults)
+3. Never disable Prettier rules without explicit user approval
+</instructions>

--- a/.windsurf/skills/ai-code-review/SKILL.md
+++ b/.windsurf/skills/ai-code-review/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: ai-code-review
+description: Review code changes for bugs and issues, present findings interactively, and save a review output summary
+---
+
+## Goal
+
+Perform a local, GitHub-style PR code review and write the resulting review comments to a single local markdown file for downstream processing.
+
+This skill must not apply fixes. It must only generate review findings and overwrite the output file.
+
+## Step 1: Compute GitHub-Style PR Diff (Local)
+
+Ask the user for the base branch to compare against (default: `main`).
+
+GitHub PRs use a three-dot diff (merge-base comparison). Use that comparison locally.
+
+// turbo
+
+```bash
+git fetch origin
+```
+
+```bash
+git diff --name-status origin/<base_branch>...HEAD
+```
+
+```bash
+git diff --unified=3 origin/<base_branch>...HEAD
+```
+
+## Step 2: Review Changes
+
+Follow the code review rubric from:
+
+`/.windsurf/skills/ai-code-review/code-review-guidelines.md`
+
+Identify high-confidence issues only.
+
+## Step 3: Save Review Comments File (append with deduplication)
+
+Append to the file (create if it does not exist):
+
+`.windsurf/workflows/outputs/review-comments.md`
+
+Follow the canonical schema in:
+
+`docs/workflows/review-comments.schema.md`
+
+- If the file does not exist, create it with the header and Items table
+- If the file exists, read it first, then append only new findings
+- **Avoid duplicates**: Do not add an item if a similar finding (same file + similar title/body) already exists in the file
+
+Use a format optimized for AI processing:
+
+```markdown
+| #   | Status | Source | Kind    | Severity | File            | Location | Title         | Body                     | Author | ThreadId | CommentId | Notes |
+| --- | ------ | ------ | ------- | -------- | --------------- | -------- | ------------- | ------------------------ | ------ | -------- | --------- | ----- |
+| 1   | open   | local  | general | major    | path/to/file.ts | L10-L25  | <short title> | <actionable description> |        |          |           |       |
+```
+
+If there are no issues and the file does not exist, create it with an empty Items table. If the file exists, do not modify it.

--- a/.windsurf/skills/ai-code-review/SKILL.md
+++ b/.windsurf/skills/ai-code-review/SKILL.md
@@ -41,7 +41,7 @@ Identify high-confidence issues only.
 
 Append to the file (create if it does not exist):
 
-`.windsurf/workflows/outputs/review-comments.md`
+`.windsurf/outputs/review-and-fix/review-comments.md`
 
 Follow the canonical schema in:
 

--- a/.windsurf/skills/ai-code-review/code-review-guidelines.md
+++ b/.windsurf/skills/ai-code-review/code-review-guidelines.md
@@ -1,0 +1,58 @@
+# Code Review Guidelines
+
+## Code Review Focus Areas
+
+When reviewing code, focus on these categories:
+
+### 1. Logic & Correctness
+- Logic errors and incorrect behavior
+- Edge cases that aren't handled
+- Null/undefined reference issues
+
+### 2. Concurrency & State
+- Race conditions or concurrency issues
+- Improper resource management or resource leaks
+
+### 3. Security
+- Input validation vulnerabilities
+- Authentication/authorization issues
+- Data exposure risks
+
+### 4. Caching
+- Cache staleness issues
+- Cache key-related bugs
+- Incorrect cache invalidation
+- Ineffective caching
+
+### 5. Code Quality
+- Violations of existing code patterns or conventions
+- Readability and maintainability concerns
+
+## Review Process
+
+1. **Get the diff**: `git diff main...HEAD`
+2. **Review each file** against the focus areas above
+3. **Report only high-confidence issues** - avoid speculation
+4. **Check for pre-existing bugs** in touched code
+
+## Severity Levels
+
+- 🔴 **Critical**: Security vulnerabilities, data loss, crashes
+- 🟠 **Major**: Logic errors, incorrect behavior
+- 🟡 **Minor**: Code style, minor improvements
+
+## Handling AI Reviewer Comments
+
+When a comment is from an AI reviewer (e.g. GitHub Copilot, automated review bots):
+
+1. Analyze the specific code block in full context — AI reviewers may lack project-wide awareness
+2. Investigate dependencies, associated function calls, or usage patterns to understand the code's requirements and purpose
+3. Review respective test files (if available) to validate the AI's feedback against expected behavior
+4. Propose a final change only after establishing full context of the implementation
+
+## General Guidelines
+
+1. Call multiple tools in parallel for efficiency when exploring the codebase
+2. Report pre-existing bugs in touched code to maintain code quality
+3. Only report high-confidence issues - avoid speculation
+4. If reviewing a specific git commit, local code state may differ from the commit

--- a/.windsurf/skills/ai-comments-fix/SKILL.md
+++ b/.windsurf/skills/ai-comments-fix/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: ai-comments-fix
+description: Iterate over locally saved review comments and PR feedback, apply fixes, and update the comments file
+---
+
+## Goal
+
+Read the local comments file and drive an interactive Fix/Wontfix loop until all actionable items are resolved.
+
+This skill must:
+
+- Read `.windsurf/workflows/outputs/review-comments.md`
+- Process all items regardless of `Source` (both `local` and `github` items)
+- For each item with status `open`, ask the user whether to **Fix** or **Wontfix** (Wontfix requires a reason)
+- If fixing, implement the code change using edit tools
+- Update the markdown file in-place to reflect current status
+- Use the `Source` column to distinguish between local AI findings and GitHub PR comments (this affects downstream steps but not the fix logic)
+
+## Step 1: Load Comments
+
+Open and parse:
+
+- `.windsurf/workflows/outputs/review-comments.md`
+
+Follow the canonical schema in:
+
+`docs/workflows/review-comments.schema.md`
+
+If the file does not exist or has no actionable items, tell the user and stop.
+
+## Step 2: Iterate
+
+For each item in order:
+
+1. Restate the item (file, location, title, body)
+2. Ask the user using `ask_user_question`:
+   - **Fix**: Apply a fix
+   - **Wontfix**: Keep as-is (user must provide a reason)
+
+If the user selects **Fix**:
+
+- Read the relevant file(s)
+- Make the smallest correct change
+- Ask the user to **Accept** or **Reject** the change
+- If accepted, mark the item as `fixed` in the markdown file
+- If rejected, keep the item as `open` and immediately ask the user what to do next: either retry with a different fix, apply the fix manually and confirm, or mark as `wontfix` with a reason
+
+If the user selects **Wontfix**:
+
+- Ask the user for a reason
+- Record the reason in the markdown file
+
+## Step 3: Stop Condition
+
+Continue until there are no remaining items with status `open`.
+
+## Output File Updates
+
+Maintain a table under `## Items` with these canonical columns (per `docs/workflows/review-comments.schema.md`):
+
+- `#`
+- `Status` (open | fixed | wontfix)
+- `Source` (local | github)
+- `Kind` (inline | general)
+- `Severity` (blocker | major | minor | nit)
+- `File`
+- `Location`
+- `Title`
+- `Body`
+- `Author`
+- `ThreadId`
+- `CommentId`
+- `Notes`
+
+Always overwrite the entire file when updating it.
+
+When updating items, preserve all existing columns from the canonical schema, especially `ThreadId` and `CommentId`.

--- a/.windsurf/skills/ai-comments-fix/SKILL.md
+++ b/.windsurf/skills/ai-comments-fix/SKILL.md
@@ -9,7 +9,7 @@ Read the local comments file and drive an interactive Fix/Wontfix loop until all
 
 This skill must:
 
-- Read `.windsurf/workflows/outputs/review-comments.md`
+- Read `.windsurf/outputs/review-and-fix/review-comments.md`
 - Process all items regardless of `Source` (both `local` and `github` items)
 - For each item with status `open`, ask the user whether to **Fix** or **Wontfix** (Wontfix requires a reason)
 - If fixing, implement the code change using edit tools
@@ -20,7 +20,7 @@ This skill must:
 
 Open and parse:
 
-- `.windsurf/workflows/outputs/review-comments.md`
+- `.windsurf/outputs/review-and-fix/review-comments.md`
 
 Follow the canonical schema in:
 

--- a/.windsurf/skills/create-pull-request/SKILL.md
+++ b/.windsurf/skills/create-pull-request/SKILL.md
@@ -54,16 +54,16 @@ Use the following company PR template. Remove any sections that are not relevant
 3. **How were the changes done?** — Highlight key design decisions from the diff (e.g. new patterns, libraries, architectural choices)
 4. **How was testing done?** — Check for test files in the diff. If none, note that and ask the user
 5. **Screenshots/Recording** — Skip unless the user provides them
-6. **AI Code Review Summary** — If `.windsurf/workflows/outputs/review-comments.md` exists, include relevant items + summary from it. If no review comments exist, remove this section
+6. **AI Code Review Summary** — If `.windsurf/outputs/review-and-fix/review-comments.md` exists, include relevant items + summary from it. If no review comments exist, remove this section
 7. **Anything Else?** — Note any technical debt, trade-offs, or follow-up work identified during review
 
 ## PR Creation (MCP)
 
-1. Always write the PR body to a temp file at `.windsurf/workflows/outputs/pr-body.md` first
+1. Always write the PR body to a temp file at `.windsurf/outputs/review-and-fix/pr-body.md` first
 2. Use `mcp0_create_pull_request` with:
    - `head`: current branch
    - `base`: base branch (e.g. `main`)
-3. Use the generated PR title and the contents of `.windsurf/workflows/outputs/pr-body.md` as the PR title/body
+3. Use the generated PR title and the contents of `.windsurf/outputs/review-and-fix/pr-body.md` as the PR title/body
 
 ## Guidelines
 

--- a/.windsurf/skills/create-pull-request/SKILL.md
+++ b/.windsurf/skills/create-pull-request/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: create-pull-request
+description: Create a pull request with a well-structured title and description following the company PR template
+---
+
+## PR Title
+
+Generate the title using conventional commit format:
+
+`type(scope): concise description`
+
+- Derive the type from the nature of changes (feat, fix, refactor, docs, chore, etc.)
+- Derive the scope from the primary area of code affected
+- Keep it concise and descriptive
+
+## PR Description Template
+
+Use the following company PR template. Remove any sections that are not relevant.
+
+```markdown
+## What does this change do?
+
+<!-- Summarize the net change in clear prose -->
+
+## Why is this change needed?
+
+<!-- Explain the engineering goal and business objective -->
+
+## How were the changes done?
+
+<!-- Highlight significant design decisions -->
+
+## How was testing done?
+
+<!-- Describe test approach and results -->
+
+## Screenshots/Recording (optional)
+
+<!-- Before/after screenshots or flow recordings -->
+
+## AI Code Review Summary
+
+<!-- Auto-generated from pre-push code review -->
+
+## Anything Else?
+
+<!-- Architecture changes, technical debt, challenges, optimizations -->
+```
+
+## How to Populate the Description
+
+1. **What does this change do?** — Summarize from the commit messages and diff
+2. **Why is this change needed?** — Infer from branch name, commits, and any review output. If unclear, ask the user
+3. **How were the changes done?** — Highlight key design decisions from the diff (e.g. new patterns, libraries, architectural choices)
+4. **How was testing done?** — Check for test files in the diff. If none, note that and ask the user
+5. **Screenshots/Recording** — Skip unless the user provides them
+6. **AI Code Review Summary** — If `.windsurf/workflows/outputs/review-comments.md` exists, include relevant items + summary from it. If no review comments exist, remove this section
+7. **Anything Else?** — Note any technical debt, trade-offs, or follow-up work identified during review
+
+## PR Creation (MCP)
+
+1. Always write the PR body to a temp file at `.windsurf/workflows/outputs/pr-body.md` first
+2. Use `mcp0_create_pull_request` with:
+   - `head`: current branch
+   - `base`: base branch (e.g. `main`)
+3. Use the generated PR title and the contents of `.windsurf/workflows/outputs/pr-body.md` as the PR title/body
+
+## Guidelines
+
+- Remove empty sections from the final PR description
+- Keep descriptions factual — don't speculate about intent if unclear, ask the user
+- Reference issue/ticket numbers if available (e.g. from branch name like `feature/TICKET-123-description`)
+- Use bullet points for lists of changes rather than long paragraphs

--- a/.windsurf/skills/fetch-pr-comments/SKILL.md
+++ b/.windsurf/skills/fetch-pr-comments/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: fetch-pr-comments
+description: Fetch PR review comments once and save them to a local markdown file for later fixing
+---
+
+## Goal
+
+Fetch PR feedback from GitHub (inline review threads and general PR comments) and write it to a single local markdown file for downstream processing.
+
+This skill must not apply fixes. It must only fetch/normalize and overwrite the output file.
+
+## Step 1: Preconditions
+
+The caller must provide the PR number. If no PR number is available, stop.
+
+## Step 2: Fetch Comments (once)
+
+Use the GitHub MCP server to fetch PR comments:
+
+- `mcp0_pull_request_read` with method `get_comments` for general PR comments
+- `mcp0_pull_request_read` with method `get_review_comments` for inline code review comments
+
+Normalize the results into a list of actionable items:
+
+- Inline: unresolved threads only, capture `threadId`, `path`, `line` (or range), `author`, `body`, and `is_resolved`/`is_outdated`
+- General: actionable comments only (skip notifications)
+
+If a single comment contains multiple actionable points, split it into separate items.
+
+## Step 3: Save Comments File (append)
+
+Append to the file (create if it does not exist):
+
+- `.windsurf/workflows/outputs/review-comments.md`
+
+Follow the canonical schema in:
+
+`docs/workflows/review-comments.schema.md`
+
+- If the file does not exist, create it with the header and an empty Items table
+- If the file exists, read it first, then append new items to the existing Items table
+- Preserve existing items (do not duplicate items with the same `ThreadId` or `CommentId`)
+
+Use an AI-friendly format for new items:
+
+```markdown
+| #   | Status | Source | Kind   | Severity | File            | Location | Title         | Body              | Author   | ThreadId   | CommentId | Notes |
+| --- | ------ | ------ | ------ | -------- | --------------- | -------- | ------------- | ----------------- | -------- | ---------- | --------- | ----- |
+| 1   | open   | github | inline | major    | path/to/file.ts | L10      | <short title> | <actionable body> | <author> | <threadId> |           |       |
+```
+
+If there are no actionable comments, do not modify the file (or create it empty if it doesn't exist).

--- a/.windsurf/skills/fetch-pr-comments/SKILL.md
+++ b/.windsurf/skills/fetch-pr-comments/SKILL.md
@@ -31,7 +31,7 @@ If a single comment contains multiple actionable points, split it into separate 
 
 Append to the file (create if it does not exist):
 
-- `.windsurf/workflows/outputs/review-comments.md`
+- `.windsurf/outputs/review-and-fix/review-comments.md`
 
 Follow the canonical schema in:
 

--- a/.windsurf/workflows/review-and-fix.md
+++ b/.windsurf/workflows/review-and-fix.md
@@ -122,7 +122,7 @@ Check `.windsurf/workflows/outputs/review-comments.md`.
 
 If there are no remaining items with status `open` (i.e. all items are marked `fixed` or `wontfix`), stop the loop and proceed to Step 7.
 
-Otherwise, return to Step 5 to continue addressing open items.
+Otherwise, return to Step 4 to continue the review loop.
 
 ---
 

--- a/.windsurf/workflows/review-and-fix.md
+++ b/.windsurf/workflows/review-and-fix.md
@@ -1,0 +1,297 @@
+---
+description: Review unpushed changes, manage PRs, and address review comments
+---
+
+# Review and Fix Workflow
+
+This workflow reviews unpushed code changes, creates or updates PRs, and addresses reviewer feedback — all in one flow.
+
+## Prerequisites
+
+All of the following **must** succeed. If **any** check fails, inform the user of the specific failure and **stop the workflow immediately** — do not proceed to any subsequent steps.
+
+1. **GitHub MCP Server** — Check that the server is configured and connected by listing available tools
+2. **GitHub CLI (`gh`)** — Verify it is installed and authenticated:
+
+```bash
+gh auth status
+```
+
+3. **Clean working tree** — Abort the workflow if there are any uncommitted changes:
+
+```bash
+git status --porcelain
+```
+
+If any output is returned, tell the user to commit or stash local changes and stop the workflow.
+
+---
+
+## Step 1: Confirm Branch
+
+Ensure the workflow output directory exists:
+
+```bash
+mkdir -p .windsurf/workflows/outputs
+```
+
+// turbo
+
+```bash
+git branch --show-current
+```
+
+Record this as the starting branch (the branch to restore back to at the end of the workflow).
+
+Create a workflow metadata file (if it does not already exist):
+
+`docs/workflows/review-and-fix.metadata.json`
+
+Use it to store defaults that should not be asked every run:
+
+- `defaultBaseBranch`
+- `defaultReviewers`
+
+If `defaultBaseBranch` is empty, prompt the user for the base branch (e.g. `main`) and update `docs/workflows/review-and-fix.metadata.json` so the next run does not need to ask again.
+
+Ask the user to confirm this is the branch they want to review using `ask_user_question` with options:
+
+- **Yes**: Continue with this branch
+- **No**: Let the user specify the correct branch
+
+If the user selects **No**, ask them for the branch name and switch to it:
+
+```bash
+git checkout <branch_name>
+```
+
+---
+
+## Step 2: Check for Open PR
+
+Check if the current branch has an open PR using:
+
+- Determine the repo owner automatically:
+
+```bash
+gh repo view --json owner -q .owner.login
+```
+
+- `mcp0_list_pull_requests` with `head` set to `<owner>:<branch_name>`
+
+If a PR exists, create/overwrite `.windsurf/workflows/outputs/pr-context.json` with:
+
+- `prNumber`
+- `prSource`: `github`
+
+Then proceed to Step 3.
+
+If no PR exists, proceed to Step 4.
+
+---
+
+## Step 3: Fetch PR Comments
+
+If `.windsurf/workflows/outputs/pr-context.json` exists, read `prNumber` from it and invoke the `fetch-pr-comments` skill.
+
+This skill must fetch PR comments only once and append them to `.windsurf/workflows/outputs/review-comments.md` (create the file if it does not exist).
+
+If `.windsurf/workflows/outputs/pr-context.json` does not exist, skip this step.
+
+---
+
+## Step 4: Run Local PR Review (AI)
+
+Invoke the `ai-code-review` skill.
+
+This skill's sole purpose is to run a local PR-style code review and append findings to `.windsurf/workflows/outputs/review-comments.md` (create the file if it does not exist). If the file already exists, avoid duplicating any comments that are already present.
+
+---
+
+## Step 5: Address Review Comments (AI)
+
+Invoke the `ai-comments-fix` skill.
+
+This skill must iterate over `.windsurf/workflows/outputs/review-comments.md` and guide the user through Fix/Wontfix decisions, applying fixes and updating the file until there are no remaining open items.
+
+---
+
+## Step 6: Review Loop
+
+Check `.windsurf/workflows/outputs/review-comments.md`.
+
+If there are no remaining items with status `open` (i.e. all items are marked `fixed` or `wontfix`), stop the loop and proceed to Step 7.
+
+Otherwise, return to Step 5 to continue addressing open items.
+
+---
+
+## Step 7: Commit Changes
+
+After the review loop is done, commit the changes:
+
+Note: this repo runs `npm run test-all` in the Husky pre-commit hook. Do not duplicate these checks here.
+
+```bash
+git add <modified_files>
+```
+
+Do not stage or commit any workflow output files:
+
+- `.windsurf/workflows/outputs/review-comments.md`
+- `.windsurf/workflows/outputs/pr-body.md`
+- `.windsurf/workflows/outputs/pr-context.json`
+
+Before committing, verify the staged files do not include these paths:
+
+```bash
+git diff --cached --name-only
+```
+
+```bash
+git commit -m "<conventional_commit_message>"
+```
+
+If the commit command fails, the workflow must abort. This commonly indicates the Husky pre-commit hook failed (e.g. `npm run test-all`).
+
+Follow the commit message rules for formatting and bullet point details.
+
+---
+
+## Step 8: Push Changes/Update PR
+
+Push the branch:
+
+```bash
+git push
+```
+
+If `git push` fails:
+
+- Ask the user whether a force push is allowed
+- If the user says **no**, abort the workflow
+- If the user says **yes**, retry with:
+
+```bash
+git push --force-with-lease
+```
+
+---
+
+## Step 9: Create PR
+
+If `.windsurf/workflows/outputs/pr-context.json` exists, move to step 10. Otherwise, create a PR:
+
+Create the PR using the `create-pull-request` skill:
+
+Record the PR number for the remaining steps.
+
+Create/overwrite `.windsurf/workflows/outputs/pr-context.json` with:
+
+- `prNumber`
+- `prSource`: `workflow`
+
+---
+
+## Step 10: Post Task Link Comment
+
+If `prSource` in `.windsurf/workflows/outputs/pr-context.json` is not `workflow`, skip this step.
+
+Add a comment to the PR using `mcp0_add_issue_comment` containing this markdown link:
+
+`[<branch-name>](https://bridge.commutatus.com/cm_admin/tasks/<branch-name>)`
+
+---
+
+## Step 11: Mark Resolved Comments on GitHub
+
+If `prSource` in `.windsurf/workflows/outputs/pr-context.json` is `workflow`, skip this step.
+
+### Inline Review Comments
+
+If `.windsurf/workflows/outputs/review-comments.md` does not exist or has no items with `Source: github`, skip this step.
+
+Use the `ThreadId` column from items with `Source: github` (per `docs/workflows/review-comments.schema.md`) when resolving threads.
+
+For each resolved comment (not ignored), resolve the thread:
+
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: {threadId: "<THREAD_ID>"}) {
+    thread { isResolved }
+  }
+}'
+```
+
+Multiple threads can be resolved in a single mutation by using aliases (t1, t2, etc.).
+
+---
+
+## Step 12: Post Summary Comment
+
+Post a run marker + summary comment on the PR using `mcp0_add_issue_comment`.
+
+First, get the latest commit SHA:
+
+```bash
+git rev-parse HEAD
+```
+
+Include a clear marker at the top so reviewers know the workflow was run:
+
+- Workflow: `review-and-fix`
+- Timestamp: <timestamp>
+- Commit: `<sha>`
+
+Then include a markdown body containing:
+
+If `.windsurf/workflows/outputs/review-comments.md` exists and has items with `Source: github`, include:
+
+- **Inline Review Comments** — table with items where `Source: github` and `Kind: inline`, showing reviewer, file, comment, and status (✅ Fixed / 🚫 Wontfix)
+- **General PR Comments** — table with items where `Source: github` and `Kind: general`, showing reviewer, comment, and status
+
+Do not include any items with `Source: local` in the GitHub comment.
+
+Always include:
+
+- **Changes** — bullet list of changes made
+
+---
+
+## Step 13: Request Human Review
+
+Request review using the GitHub MCP server:
+
+- Load `defaultReviewers` from `docs/workflows/review-and-fix.metadata.json`
+- Read the PR number from `.windsurf/workflows/outputs/pr-context.json`
+- Use `mcp0_pull_request_read` to get PR details and determine the PR author
+- If the PR author is in `defaultReviewers`, remove them from the reviewers list
+- Use `mcp0_update_pull_request` with the PR number and `reviewers` set to the filtered `defaultReviewers`
+
+---
+
+## Step 14: Cleanup
+
+Delete any review output files generated during this workflow:
+
+```bash
+rm -f .windsurf/workflows/outputs/pr-body.md .windsurf/workflows/outputs/pr-context.json
+rm -f .windsurf/workflows/outputs/review-comments.md
+```
+
+---
+
+## Summary
+
+Present final status to the user:
+
+| Task                   | Status                  |
+| ---------------------- | ----------------------- |
+| Review loop            | ✅ Done                 |
+| Commit changes         | ✅ Committed            |
+| Create/update PR       | ✅ Done                 |
+| Mark comments resolved | ✅ X resolved           |
+| Post run marker        | ✅ Posted               |
+| Request human review   | ✅ Reviewers requested  |
+| Cleanup                | ✅ Output files deleted |

--- a/.windsurf/workflows/review-and-fix.md
+++ b/.windsurf/workflows/review-and-fix.md
@@ -31,8 +31,10 @@ If any output is returned, tell the user to commit or stash local changes and st
 
 Ensure the workflow output directory exists:
 
+This workflow stores its generated artifacts under `.windsurf/outputs/review-and-fix/`
+
 ```bash
-mkdir -p .windsurf/workflows/outputs
+mkdir -p .windsurf/outputs/review-and-fix
 ```
 
 // turbo
@@ -79,7 +81,7 @@ gh repo view --json owner -q .owner.login
 
 - `mcp0_list_pull_requests` with `head` set to `<owner>:<branch_name>`
 
-If a PR exists, create/overwrite `.windsurf/workflows/outputs/pr-context.json` with:
+If a PR exists, create/overwrite `.windsurf/outputs/review-and-fix/pr-context.json` with:
 
 - `prNumber`
 - `prSource`: `github`
@@ -92,11 +94,11 @@ If no PR exists, proceed to Step 4.
 
 ## Step 3: Fetch PR Comments
 
-If `.windsurf/workflows/outputs/pr-context.json` exists, read `prNumber` from it and invoke the `fetch-pr-comments` skill.
+If `.windsurf/outputs/review-and-fix/pr-context.json` exists, read `prNumber` from it and invoke the `fetch-pr-comments` skill.
 
-This skill must fetch PR comments only once and append them to `.windsurf/workflows/outputs/review-comments.md` (create the file if it does not exist).
+This skill must fetch PR comments only once and append them to `.windsurf/outputs/review-and-fix/review-comments.md` (create the file if it does not exist).
 
-If `.windsurf/workflows/outputs/pr-context.json` does not exist, skip this step.
+If `.windsurf/outputs/review-and-fix/pr-context.json` does not exist, skip this step.
 
 ---
 
@@ -104,7 +106,7 @@ If `.windsurf/workflows/outputs/pr-context.json` does not exist, skip this step.
 
 Invoke the `ai-code-review` skill.
 
-This skill's sole purpose is to run a local PR-style code review and append findings to `.windsurf/workflows/outputs/review-comments.md` (create the file if it does not exist). If the file already exists, avoid duplicating any comments that are already present.
+This skill's sole purpose is to run a local PR-style code review and append findings to `.windsurf/outputs/review-and-fix/review-comments.md` (create the file if it does not exist). If the file already exists, avoid duplicating any comments that are already present.
 
 ---
 
@@ -112,13 +114,13 @@ This skill's sole purpose is to run a local PR-style code review and append find
 
 Invoke the `ai-comments-fix` skill.
 
-This skill must iterate over `.windsurf/workflows/outputs/review-comments.md` and guide the user through Fix/Wontfix decisions, applying fixes and updating the file until there are no remaining open items.
+This skill must iterate over `.windsurf/outputs/review-and-fix/review-comments.md` and guide the user through Fix/Wontfix decisions, applying fixes and updating the file until there are no remaining open items.
 
 ---
 
 ## Step 6: Review Loop
 
-Check `.windsurf/workflows/outputs/review-comments.md`.
+Check `.windsurf/outputs/review-and-fix/review-comments.md`.
 
 If there are no remaining items with status `open` (i.e. all items are marked `fixed` or `wontfix`), stop the loop and proceed to Step 7.
 
@@ -138,9 +140,9 @@ git add <modified_files>
 
 Do not stage or commit any workflow output files:
 
-- `.windsurf/workflows/outputs/review-comments.md`
-- `.windsurf/workflows/outputs/pr-body.md`
-- `.windsurf/workflows/outputs/pr-context.json`
+- `.windsurf/outputs/review-and-fix/review-comments.md`
+- `.windsurf/outputs/review-and-fix/pr-body.md`
+- `.windsurf/outputs/review-and-fix/pr-context.json`
 
 Before committing, verify the staged files do not include these paths:
 
@@ -180,36 +182,26 @@ git push --force-with-lease
 
 ## Step 9: Create PR
 
-If `.windsurf/workflows/outputs/pr-context.json` exists, move to step 10. Otherwise, create a PR:
+If `.windsurf/outputs/review-and-fix/pr-context.json` exists, move to step 10. Otherwise, create a PR:
 
 Create the PR using the `create-pull-request` skill:
 
 Record the PR number for the remaining steps.
 
-Create/overwrite `.windsurf/workflows/outputs/pr-context.json` with:
+Create/overwrite `.windsurf/outputs/review-and-fix/pr-context.json` with:
 
 - `prNumber`
 - `prSource`: `workflow`
 
 ---
 
-## Step 10: Post Task Link Comment
+## Step 10: Mark Resolved Comments on GitHub
 
-If `prSource` in `.windsurf/workflows/outputs/pr-context.json` is not `workflow`, skip this step.
-
-Add a comment to the PR using `mcp0_add_issue_comment` containing this markdown link:
-
-`[<branch-name>](https://bridge.commutatus.com/cm_admin/tasks/<branch-name>)`
-
----
-
-## Step 11: Mark Resolved Comments on GitHub
-
-If `prSource` in `.windsurf/workflows/outputs/pr-context.json` is `workflow`, skip this step.
+If `prSource` in `.windsurf/outputs/review-and-fix/pr-context.json` is `workflow`, skip this step.
 
 ### Inline Review Comments
 
-If `.windsurf/workflows/outputs/review-comments.md` does not exist or has no items with `Source: github`, skip this step.
+If `.windsurf/outputs/review-and-fix/review-comments.md` does not exist or has no items with `Source: github`, skip this step.
 
 Use the `ThreadId` column from items with `Source: github` (per `docs/workflows/review-comments.schema.md`) when resolving threads.
 
@@ -228,7 +220,7 @@ Multiple threads can be resolved in a single mutation by using aliases (t1, t2, 
 
 ---
 
-## Step 12: Post Summary Comment
+## Step 11: Post Summary Comment
 
 Post a run marker + summary comment on the PR using `mcp0_add_issue_comment`.
 
@@ -246,7 +238,7 @@ Include a clear marker at the top so reviewers know the workflow was run:
 
 Then include a markdown body containing:
 
-If `.windsurf/workflows/outputs/review-comments.md` exists and has items with `Source: github`, include:
+If `.windsurf/outputs/review-and-fix/review-comments.md` exists and has items with `Source: github`, include:
 
 - **Inline Review Comments** — table with items where `Source: github` and `Kind: inline`, showing reviewer, file, comment, and status (✅ Fixed / 🚫 Wontfix)
 - **General PR Comments** — table with items where `Source: github` and `Kind: general`, showing reviewer, comment, and status
@@ -259,25 +251,24 @@ Always include:
 
 ---
 
-## Step 13: Request Human Review
+## Step 12: Request Human Review
 
 Request review using the GitHub MCP server:
 
 - Load `defaultReviewers` from `docs/workflows/review-and-fix.metadata.json`
-- Read the PR number from `.windsurf/workflows/outputs/pr-context.json`
+- Read the PR number from `.windsurf/outputs/review-and-fix/pr-context.json`
 - Use `mcp0_pull_request_read` to get PR details and determine the PR author
 - If the PR author is in `defaultReviewers`, remove them from the reviewers list
 - Use `mcp0_update_pull_request` with the PR number and `reviewers` set to the filtered `defaultReviewers`
 
 ---
 
-## Step 14: Cleanup
+## Step 13: Cleanup
 
 Delete any review output files generated during this workflow:
 
 ```bash
-rm -f .windsurf/workflows/outputs/pr-body.md .windsurf/workflows/outputs/pr-context.json
-rm -f .windsurf/workflows/outputs/review-comments.md
+rm -f .windsurf/outputs/review-and-fix/
 ```
 
 ---

--- a/docs/workflows/github-mcp.md
+++ b/docs/workflows/github-mcp.md
@@ -1,0 +1,15 @@
+Example windsurf config:
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "serverUrl": "https://api.githubcopilot.com/mcp/",
+      "headers": {
+        "Authorization": "Bearer [token goes here]"
+      }
+    }
+  }
+}
+```
+

--- a/docs/workflows/review-and-fix.metadata.json
+++ b/docs/workflows/review-and-fix.metadata.json
@@ -1,6 +1,6 @@
 {
   "workflow": "review-and-fix",
-  "defaultBaseBranch": "",
+  "defaultBaseBranch": "main",
   "defaultReviewers": ["gpalsingh", "mikevic"],
   "notes": "Fill in any defaults you want the workflow to reuse across runs."
 }

--- a/docs/workflows/review-and-fix.metadata.json
+++ b/docs/workflows/review-and-fix.metadata.json
@@ -1,0 +1,6 @@
+{
+  "workflow": "review-and-fix",
+  "defaultBaseBranch": "",
+  "defaultReviewers": ["gpalsingh", "mikevic"],
+  "notes": "Fill in any defaults you want the workflow to reuse across runs."
+}

--- a/docs/workflows/review-comments.schema.md
+++ b/docs/workflows/review-comments.schema.md
@@ -13,7 +13,7 @@ This document defines the canonical markdown schema for review comment files pro
 
 ## Files
 
-- `.windsurf/workflows/outputs/review-comments.md` — review comments for the current workflow pass
+- `.windsurf/outputs/review-and-fix/review-comments.md` — review comments for the current workflow pass
 
 ## Required Frontmatter Section
 

--- a/docs/workflows/review-comments.schema.md
+++ b/docs/workflows/review-comments.schema.md
@@ -1,0 +1,94 @@
+---
+description: Canonical schema for review comments files used by review-and-fix workflow and skills
+---
+
+# Review Comments Schema
+
+This document defines the canonical markdown schema for review comment files produced/consumed by:
+
+- `.windsurf/workflows/review-and-fix.md`
+- `.windsurf/skills/ai-code-review`
+- `.windsurf/skills/fetch-pr-comments`
+- `.windsurf/skills/ai-comments-fix`
+
+## Files
+
+- `.windsurf/workflows/outputs/review-comments.md` — review comments for the current workflow pass
+
+## Required Frontmatter Section
+
+The file must start with:
+
+```markdown
+# Review Comments
+
+**GeneratedAt**: <timestamp>
+```
+
+Optionally, you may include:
+
+- `**Branch**: <branch_name>` — the branch being reviewed
+- `**Base**: <base_branch>` — the base branch for comparison
+- `**PR**: <pr_number>` — if reviewing an existing PR
+
+### Per-Item Source Discriminator
+
+The `Source` column in the Items table is the primary discriminator:
+
+- `local` — AI-generated review findings
+- `github` — GitHub PR comments (inline or general)
+
+Downstream steps use `Source` (not file-level `Type`) to determine behavior:
+
+- Only items with `Source: github` can have `ThreadId` for resolving threads
+- Only `Source: github` items appear in PR summary comment tables
+- `Source: local` items are kept internal to the workflow
+
+## Items Table
+
+Each file must contain an `## Items` section with a single table.
+
+### Canonical Columns
+
+These columns must exist in this exact order (values may be empty when not applicable):
+
+- `#`
+- `Status` (open | fixed | wontfix)
+- `Source` (local | github)
+- `Kind` (inline | general)
+- `Severity` (blocker | major | minor | nit)
+- `File`
+- `Location`
+- `Title`
+- `Body`
+- `Author`
+- `ThreadId`
+- `CommentId`
+- `Notes`
+
+### Column Semantics
+
+- `ThreadId`
+  - Required for GitHub inline comments when available.
+  - Used by the workflow to resolve threads.
+  - Must be preserved by any tool that updates the file.
+- `CommentId`
+  - Optional identifier if available from GitHub APIs.
+- `Severity`
+  - For `pr_comments`, set to `major` by default unless the reviewer clearly indicates severity.
+- `Title`
+  - For `pr_comments`, derive a short title from the comment.
+- `Location`
+  - Use `L<start>` or `L<start>-L<end>` when possible.
+
+### Wontfix
+
+When `Status` is `wontfix`, `Notes` must include the reason.
+
+### Empty State
+
+If there are no actionable items, still write the file with:
+
+- A valid header
+- `## Items` section
+- Table header row + separator row only (no item rows)


### PR DESCRIPTION
## What does this change do?

- Adds a reusable `/review-and-fix` workflow for PR review loops (fetch PR comments, run local AI review, apply fixes, commit/push, and update/create PRs)
- Adds supporting skills and a canonical review-comments schema for consistent downstream automation

## Why is this change needed?

- Standardizes the PR review + fix process so it’s repeatable and less error-prone across runs

## How were the changes done?

- Introduced a single workflow definition under `.windsurf/workflows/review-and-fix.md`
- Added skill definitions under `.windsurf/skills/*` and a schema under `docs/workflows/review-comments.schema.md`
- Stored reusable defaults in `docs/workflows/review-and-fix.metadata.json`

## How was testing done?

- Verified via Husky pre-commit hook (`npm run test-all`: lint + staging build)

## AI Code Review Summary

- No actionable items (all findings resolved or marked `wontfix` in `.windsurf/workflows/outputs/review-comments.md`)

## Anything Else?

- None
